### PR TITLE
Add wireviz support to the ruby gem

### DIFF
--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -133,6 +133,7 @@ module AsciidoctorExtensions
       wavedrom
       structurizr
       diagramsnet
+      wireviz
     ].freeze
   end
 


### PR DESCRIPTION
Add **wireviz** to the list of supported block types for the Ruby Gem. This were missing in #423.

Fixes functional part of #440. Tests still needed.