### PR TITLE
Fix preprocess of subfolder includes for antora

### DIFF
--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -180,7 +180,8 @@ function resolveIncludeFile (includeFile, resource, includePaths, vfs) {
   const exists = typeof vfs !== 'undefined' && typeof vfs.exists === 'function' ? vfs.exists : require('./node-fs.js').exists
   if (resource.module) {
     // antora resource id
-    return includeFile
+    const dirPath = path.dirname(resource.relative)
+    return path.join(dirPath, includeFile)
   }
   let filePath = includeFile
   for (const includePath of [resource.dir, ...includePaths]) {

--- a/test/antora/docs/modules/ROOT/pages/source-location.adoc
+++ b/test/antora/docs/modules/ROOT/pages/source-location.adoc
@@ -65,6 +65,16 @@ plantuml::partial$ab_inc.puml[target=ab-inc-partial-1,format=svg]
 
 NOTE: `ab_inc.puml` is using the PlantUML `!include` directive to include another file.
 
+== Include a partial from subfolder using plantuml macro
+
+....
+plantuml::partial$sub/ab_sub_inc.puml[target=ab-inc-sub-partial-1,format=svg]
+....
+
+plantuml::partial$sub/ab_sub_inc.puml[target=ab-inc-sub-partial-1,format=svg]
+
+NOTE: `sub/ab_sub_inc.puml` is using the PlantUML `!include` directive to include another file.
+
 == Include an example (.puml extension)
 
 ....

--- a/test/antora/docs/modules/ROOT/partials/sub/ab_sub_inc.puml
+++ b/test/antora/docs/modules/ROOT/partials/sub/ab_sub_inc.puml
@@ -1,0 +1,3 @@
+@startuml
+!include sub/ab_sub_sub_inc.puml
+@enduml

--- a/test/antora/docs/modules/ROOT/partials/sub/sub/ab_sub_sub_inc.puml
+++ b/test/antora/docs/modules/ROOT/partials/sub/sub/ab_sub_sub_inc.puml
@@ -1,0 +1,3 @@
+@startuml
+!include sub/ab_sub_sub_sub.puml
+@enduml

--- a/test/antora/docs/modules/ROOT/partials/sub/sub/sub/ab_sub_sub_sub.puml
+++ b/test/antora/docs/modules/ROOT/partials/sub/sub/sub/ab_sub_sub_sub.puml
@@ -1,0 +1,2 @@
+alice -> bob
+bob -> alice

--- a/test/antora/test.spec.js
+++ b/test/antora/test.spec.js
@@ -17,7 +17,7 @@ describe('Antora integration (local)', function () {
   it('should generate a site with diagrams', () => {
     const $ = cheerio.load(fs.readFileSync(`${__dirname}/public/antora-kroki/source-location.html`))
     const imageElements = $('img')
-    expect(imageElements.length).to.equal(7)
+    expect(imageElements.length).to.equal(8)
     imageElements.each((i, imageElement) => {
       const src = $(imageElement).attr('src')
       expect(src).to.startWith('_images/ab-')
@@ -26,6 +26,15 @@ describe('Antora integration (local)', function () {
   it('should resolve included diagrams when using plantuml::partial$xxx.puml[] macro', async () => {
     const $ = cheerio.load(fs.readFileSync(`${__dirname}/public/antora-kroki/source-location.html`))
     const imageElement = $('img[alt*=ab-inc-partial-1]')
+    expect(imageElement.length).to.equal(1)
+    const src = imageElement.attr('src')
+    const diagramContents = fs.readFileSync(`${__dirname}/public/antora-kroki/${src}`).toString()
+    expect(diagramContents).includes('alice')
+    expect(diagramContents).includes('bob')
+  })
+  it('should resolve included diagrams from subfolders when using plantuml::partial$subfolder/xxx.puml[] macro', async () => {
+    const $ = cheerio.load(fs.readFileSync(`${__dirname}/public/antora-kroki/source-location.html`))
+    const imageElement = $('img[alt*=ab-inc-sub-partial-1]')
     expect(imageElement.length).to.equal(1)
     const src = imageElement.attr('src')
     const diagramContents = fs.readFileSync(`${__dirname}/public/antora-kroki/${src}`).toString()


### PR DESCRIPTION
The preprocessing needs to respect the folder of the current processed file because the includes are relative to this file.