### PR TITLE
fix(doc): use consistent blocks delimiter for include macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ vegalite::partial$chart.vlite[svg,role=chart,opts=interactive]
 
 ```adoc
 [plantuml,alice-bob,svg,role=sequence]
-----
+....
 include::partial$alice-bob.puml[]
-----
+....
 ```
 
 


### PR DESCRIPTION
Consistently using delimited blocks for include macro. Fixes #458